### PR TITLE
fix: canceled order still shows button, and able to go to process page (DBIO-492)

### DIFF
--- a/src/components/Dialog/DialogAlert.vue
+++ b/src/components/Dialog/DialogAlert.vue
@@ -8,7 +8,7 @@
       <div align="center" class="pb-5 pl-5 pr-5">{{ textAlert }}</div>
       <div class="d-flex justify-center pb-5">
         <v-col lg="5" md="5" sm="8">
-          <Button @click="closeDialog" elevation="2" dark color="blue"> {{ btnText }} </Button>
+          <Button @click="closeDialog" elevation="2" dark color="primary"> {{ btnText }} </Button>
         </v-col>
       </div>
     </v-card>

--- a/src/views/Dashboard/Lab/OrderHistory/ProcessOrder/index.vue
+++ b/src/views/Dashboard/Lab/OrderHistory/ProcessOrder/index.vue
@@ -124,6 +124,15 @@
                     @uploadGenome="uploadedGenomeCheckbox = true"
                     @uploadReport="uploadedReportCheckbox = true"
                     @submitTestResult="submitTestResult" />
+                <DialogAlert
+                    :show="cancelledOrderDialog"
+                    btnText="Back"
+                    textAlert="Order has been cancelled"
+                    imgPath="warning.png"
+                    imgWidth="50"
+                    @toggle="cancelledOrderDialog = $event"
+                    @close="$router.push('/lab/orders')"
+                ></DialogAlert>
             </v-col>
         </v-row>
       </v-container>
@@ -137,6 +146,7 @@ import QualityControlSpecimen from './QualityControlSpecimen'
 import WetworkSpecimen from './WetworkSpecimen'
 import ProcessSpecimen from './ProcessSpecimen'
 import { getOrdersDetail } from '@/lib/polkadotProvider/query/orders'
+import DialogAlert from '@/components/Dialog/DialogAlert'
 
 export default {
   name: 'ProcessOrderHistory',
@@ -145,6 +155,7 @@ export default {
     QualityControlSpecimen,
     WetworkSpecimen,
     ProcessSpecimen,
+    DialogAlert,
   },
   data: () => ({
     receivedCheckbox: false,
@@ -163,6 +174,7 @@ export default {
     serviceName: "",
     serviceDescription: "",
     serviceImage: "",
+    cancelledOrderDialog: false,
   }),
   async mounted(){
     try {
@@ -171,6 +183,9 @@ export default {
         this.$router.push({ name: 'lab-dashboard-order-history' })
       }
       const order = await getOrdersDetail(this.api, this.orderId)
+      if(order.status == "Cancelled"){
+          this.cancelledOrderDialog = true
+      }
       this.serviceName = order.service_name
       this.serviceDescription = order.service_description
       this.serviceImage = order.service_image

--- a/src/views/Dashboard/Lab/OrderHistory/index.vue
+++ b/src/views/Dashboard/Lab/OrderHistory/index.vue
@@ -27,6 +27,7 @@
                   <template v-slot:[`item.actions`]="{ item }">
                      <v-container>
                         <v-btn
+                          v-if="item.status != 'Cancelled'"
                           :class="buttonClass(item)"
                           dark
                           small


### PR DESCRIPTION
### JIRA Link

https://blocksphere2020.atlassian.net/browse/DBIO-492?atlOrigin=eyJpIjoiNjE2NjZhODdlOGJkNGI5YWJlY2U5OTk1YzI0ZDg1NmUiLCJwIjoiaiJ9

### Changelog / Description
Canceled order still shows a button, and is able to go to the process page
- Fix canceled order still shows a button, and is able to go to process page