### PR TITLE
[ Fix ] Service Handler

### DIFF
--- a/src/mixins/serviceHandler.js
+++ b/src/mixins/serviceHandler.js
@@ -20,9 +20,10 @@ export default {
     addCallback(args){
       // Add callback if doesn't exist
       if(!(args[args.length - 1] instanceof Function)){
-        args.push(()=>{
+        args.push(() => {
           this.isLoading = false
         })
+
         return args
       }
       
@@ -32,6 +33,7 @@ export default {
         f()
         this.isLoading = false
       }
+
       return args
     },
 
@@ -43,7 +45,7 @@ export default {
      */
     async dispatch(action, ...args) {
       this.isLoading = true
-      args = this.addCallback(args)      
+      args = this.addCallback(args)
 
       try {
         const response = await action.apply(this, args)
@@ -55,6 +57,8 @@ export default {
         console.error(`[${error?.response?.status}] Something went wrong, Please try again later!`)
 
         return Promise.reject(error)
+      } finally {
+        this.isLoading = false
       }
     }
   }

--- a/src/views/Dashboard/Customer/OrderHistoryDetail/index.vue
+++ b/src/views/Dashboard/Customer/OrderHistoryDetail/index.vue
@@ -534,15 +534,7 @@ export default {
     },
 
     async cancelOrderRequest(status) {
-      if (status) {
-        try {
-          this.isLoading = true;
-          await cancelOrder(this.api, this.wallet, this.$route.params.number);
-        } catch (err) {
-          console.log(err);
-          this.isLoading = false;
-        }
-      }
+      if (status) this.dispatch(cancelOrder, this.api, this.wallet, this.$route.params.number)
     },
 
     isValidIcon(icon) {


### PR DESCRIPTION
### Changelog/Description
Fix and update logic `try-catch` with `finally`, please check this reference why I used `finally` here. Anyway it causing error on the checkout page, caused `isLoading` not to be `false` if we do not assign a callback function

> ### **finally_statements**
> Statements that are executed after the try statement completes. These statements execute regardless of whether an exception was thrown or caught.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch